### PR TITLE
Added generate hosts file tasks

### DIFF
--- a/tasks/generate_hosts_file.yml
+++ b/tasks/generate_hosts_file.yml
@@ -1,0 +1,8 @@
+- name: Generate hosts file on the nodes
+  ansible.builtin.template:
+    src: hosts.j2
+    dest: /etc/hosts
+    mode: '0644'
+    owner: root
+    group: root
+    backup: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,3 +44,8 @@
   tags: 
     - check_access_download_collections
   import_tasks: check_access_download_collections.yml
+
+- name: Import generate_hosts_file.yml file
+  tags:
+    - generate_hosts_file
+  import_tasks: generate_hosts_file.yml

--- a/templates/hosts.j2
+++ b/templates/hosts.j2
@@ -1,0 +1,6 @@
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+{% for host in hostvars %}
+{{ hostvars[host]['ansible_facts']['default_ipv4']['address'] }}  {{ hostvars[host]['ansible_facts']['fqdn'] }} {{ hostvars[host]['ansible_facts']['hostname'] }}
+{% endfor %}


### PR DESCRIPTION
This commit added tasks to create /etc/hosts file based on template on the target nodes with <IPADDRESS> <FQDN> <HOSTNAME> and make a backup of the old /etc/hosts file